### PR TITLE
make topbar look a little nicer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,16 @@
 
 @import "bootstrap-sprockets";
 @import "bootstrap";
+
+.navbar-header {
+    display: flex;
+    align-items: center;
+    @media (max-width: 768px) {
+        .navbar-brand {
+            flex: 1;
+        }
+        .navbar-toggle {
+            order: 1; // flexbox version of float: right
+        }
+    }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,8 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="inline home" href="//charcoal-se.org/"><img src="//charcoal-se.org/assets/images/charcoal.png" height="32"><span>by Charcoal</span></a>
-          <a class="navbar-brand" href="/">metasmoke</a>
+          <a class="inline home" href="//sobotics.github.io"><img src="https://avatars1.githubusercontent.com/u/21141173" height="32"></a>
+          <a class="navbar-brand" href="/">Redunda</a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
I replaced the Charcoal logo with the SOBotics logo, copied some CSS from Metasmoke, and changed "metasmoke" to "Redunda".

The SOBotics logo looks really bad in development, but it should look fine with the white topbar.