### PR TITLE
Add a user list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ config/config.yml
 config/database.yml
 
 .idea/*
+
+# Ignore macOS metadata
+.DS_Store

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav">
             <li class='<%= controller.class == BotsController ? "active" : "" %>'><%= link_to "bots", bots_path %></li>
+            <li class='<%= controller.class == UsersController ? "active" : "" %>'><%= link_to "users", users_path %></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <% if user_signed_in? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,25 @@
+<h3>Users</h3>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% User.all.each do |user| %>
+    <tr>
+      <td><%= user.id %></td>
+      <td>
+        <% if user.stack_exchange_account_id != 0 then %>
+          <%= link_to user.username, "//stackexchange.com/users/#{user.stack_exchange_account_id}" %>
+        <% else %>
+          <%= user.username %>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+    get 'users', to: 'users#index'
+
   devise_for :users
   root to: "bots#index"
   

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get users_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
I made a simple user list, similar to Metasmoke's User Data page.  Right now, the link is in the topbar next to "bots," but we can put it in the dropdown like Metasmoke does if we want to.

The user list contains each user's ID and their name, linking to their Stack Exchange account if it exists.