### PR TITLE
Fix grid layout

### DIFF
--- a/app/assets/stylesheets/bots.scss
+++ b/app/assets/stylesheets/bots.scss
@@ -2,12 +2,20 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+.bot-dash-module-container {
+  margin: 0px;
+  padding: 5px !important;
+}
+
 .bot-dash-module {
   border: 1px solid gray;
   border-radius: 4px;
   border-top: 4px solid gray;
-  margin: 5px;
+  padding-left: 15px;
+  padding-right: 15px;
+  margin-bottom: 5px;
 }
+
 
 .bot {
   border: 1px solid #eee;

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -1,29 +1,31 @@
 <% @bots.in_groups_of(3).each do |group| %>
   <div class="row">
     <% group.compact.each do |bot| %>
-      <div class="bot-dash-module col-md-4">
-        <h3><%= bot.name %></h3>
-        <p><%= bot.description %></p>
-        <p><strong><%= link_to "Instances", url_for(controller: :bot_instances, action: :index, bot_id: bot.id) %></strong></p>
-        <ul>
-          <% bot.bot_instances.each do |instance| %>
-            <li>
-              <code><%= link_to instance.location, url_for(:controller => :bot_instances, :action => :show, :bot_id => bot.id, :id => instance.id) %></code>
-              <em>(alive: <span class="<%= instance.status_class %>" title="<%= instance.last_ping %>">
-                            <%= instance.last_ping.nil? ? "never" : time_ago_in_words(instance.last_ping) + " ago" %></span>,
-                   owner: <%= instance.user.username %>)</em>
-            </li>
+      <div class="bot-dash-module-container col-md-4">
+        <div class="bot-dash-module col-md">
+          <h3><%= bot.name %></h3>
+          <p><%= bot.description %></p>
+          <p><strong><%= link_to "Instances", url_for(controller: :bot_instances, action: :index, bot_id: bot.id) %></strong></p>
+          <ul>
+            <% bot.bot_instances.each do |instance| %>
+              <li>
+                <code><%= link_to instance.location, url_for(:controller => :bot_instances, :action => :show, :bot_id => bot.id, :id => instance.id) %></code>
+                <em>(alive: <span class="<%= instance.status_class %>" title="<%= instance.last_ping %>">
+                              <%= instance.last_ping.nil? ? "never" : time_ago_in_words(instance.last_ping) + " ago" %></span>,
+                     owner: <%= instance.user.username %>)</em>
+              </li>
+            <% end %>
+          </ul>
+          <p><strong>Collaborators</strong></p>
+          <ul>
+              <% User.with_role(:collaborator, bot).each do |user| %>
+                  <p><%= user.username %></p>
+              <% end %>
+          </ul>
+          <% if current_user.present? and current_user.has_role? :owner, bot %>
+            <%= link_to "edit", edit_bot_path(bot) %>
           <% end %>
-        </ul>
-        <p><strong>Collaborators</strong></p>
-        <ul>
-            <% User.with_role(:collaborator, bot).each do |user| %>
-				<p><%= user.username %></p>
-			<% end %>
-		</ul>
-        <% if current_user.present? and current_user.has_role? :owner, bot %>
-          <%= link_to "edit", edit_bot_path(bot) %>
-        <% end %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
The grid layout in the bots view only occupied two columns instead of three, because the margins between the boxes caused each box to be just a bit too big:

![bad](https://cloud.githubusercontent.com/assets/19418817/23728807/8793392e-0413-11e7-8506-6659d91745e3.png)

I fixed it by making each element of the grid a container div with no margins between them, then another div containing the content as before, and some padding:

![good](https://cloud.githubusercontent.com/assets/19418817/23728866/deca43cc-0413-11e7-8fd1-5911f6f8b71b.png)

