### PR TITLE
Allow creating bot instances

### DIFF
--- a/app/controllers/bot_instances_controller.rb
+++ b/app/controllers/bot_instances_controller.rb
@@ -2,7 +2,6 @@ class BotInstancesController < ApplicationController
   before_action :authenticate_user!, :only => [:new, :create, :edit, :update, :destroy]
   before_action :set_bot_instance, only: [:show, :edit, :update, :destroy]
   before_action :check_instance_permissions, only: [:edit, :update, :destroy]
-  before_action :check_bot_permissions, only: [:new, :create]
 
   def index
     @bot = Bot.find params[:bot_id]
@@ -10,10 +9,14 @@ class BotInstancesController < ApplicationController
   end
 
   def show
+    @bot = Bot.find @bot_instance.bot_id
   end
 
   def new
+    @bot = Bot.find params[:bot_id]
     @bot_instance = BotInstance.new
+
+    check_bot_permissions
   end
 
   def edit
@@ -23,10 +26,13 @@ class BotInstancesController < ApplicationController
     @bot_instance = BotInstance.new(bot_instance_params)
     @bot_instance.bot_id = params[:bot_id]
     @bot_instance.user = current_user
+    @bot = Bot.find params[:bot_id]
+
+    check_bot_permissions
 
     respond_to do |format|
       if @bot_instance.save
-        format.html { redirect_to url_for(:controller => :bot_instances, :action => :show, :bot_id => params[:bot_id], :id => @bot_instance.id),
+        format.html { redirect_to url_for(:controller => :bot_instances, :action => :index, :bot_id => params[:bot_id]),
                                   notice: 'Bot instance was successfully created.' }
         format.json { render :show, status: :created, location: @bot_instance }
       else
@@ -74,12 +80,16 @@ class BotInstancesController < ApplicationController
     unless @bot_instance.id == current_user.id or current_user.has_role? :owner, @bot_instance.bot
       render :status => :forbidden, :plain => "You're not allowed to modify this instance" and return
     end
+
+    unless @bot_instance.bot_id.to_s == params[:bot_id]
+      render :status => :forbidden, :plain => "This instance does not belong to this bot." and return
+    end
   end
 
   # Checks that a user has permissions (either owner or collaborator) on a bot.
   # Used before *creating* a new instance
   def check_bot_permissions
-    unless current_user.has_role? :owner, @bot_instance.bot or current_user.has_role? :collaborator, @bot_instance.bot
+    unless current_user.has_role? :owner, @bot or current_user.has_role? :collaborator, @bot
       render :status => :forbidden, :plain => "You're not allowed to create an instance on this bot" and return
     end
   end

--- a/app/controllers/bot_instances_controller.rb
+++ b/app/controllers/bot_instances_controller.rb
@@ -1,22 +1,19 @@
 class BotInstancesController < ApplicationController
   before_action :authenticate_user!, :only => [:new, :create, :edit, :update, :destroy]
   before_action :set_bot_instance, only: [:show, :edit, :update, :destroy]
+  before_action :set_bot
   before_action :check_instance_permissions, only: [:edit, :update, :destroy]
+  before_action :check_bot_permissions, only: [:new, :create]
 
   def index
-    @bot = Bot.find params[:bot_id]
     @bot_instances = @bot.bot_instances
   end
 
   def show
-    @bot = Bot.find @bot_instance.bot_id
   end
 
   def new
-    @bot = Bot.find params[:bot_id]
     @bot_instance = BotInstance.new
-
-    check_bot_permissions
   end
 
   def edit
@@ -26,9 +23,6 @@ class BotInstancesController < ApplicationController
     @bot_instance = BotInstance.new(bot_instance_params)
     @bot_instance.bot_id = params[:bot_id]
     @bot_instance.user = current_user
-    @bot = Bot.find params[:bot_id]
-
-    check_bot_permissions
 
     respond_to do |format|
       if @bot_instance.save
@@ -67,6 +61,10 @@ class BotInstancesController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_bot_instance
     @bot_instance = BotInstance.find(params[:id])
+  end
+
+  def set_bot
+    @bot = Bot.find params[:bot_id]
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,6 @@
 module UsersHelper
+  # Return an HTML link for a user.
+  def user_link(user)
+    return ActionController::Base.helpers.link_to user.username, "//stackexchange.com/users/#{user.stack_exchange_account_id}"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,9 +28,4 @@ class User < ApplicationRecord
       return
     end
   end
-
-  # Helper method to return an HTML link for a user.
-  def link
-    return ActionController::Base.helpers.link_to username, "//stackexchange.com/users/#{stack_exchange_account_id}"
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,4 +28,9 @@ class User < ApplicationRecord
       return
     end
   end
+
+  # Helper method to return an HTML link for a user.
+  def link
+    return ActionController::Base.helpers.link_to username, "//stackexchange.com/users/#{stack_exchange_account_id}"
+  end
 end

--- a/app/views/bot_instances/index.html.erb
+++ b/app/views/bot_instances/index.html.erb
@@ -19,6 +19,6 @@
   <% end %>
 </ul>
 
-<% if user_signed_in? && (current_user.has_role?(:owner, @bot) || current_user.has_role?(:collaborator, @bot))%>
+<% if user_signed_in? && (current_user.has_any_role? ({name: :owner, resource: @bot, name: :collaborator, resource: @bot}))%>
   <%= link_to "Create New", new_bot_bot_instance_path %>
 <% end %>

--- a/app/views/bot_instances/index.html.erb
+++ b/app/views/bot_instances/index.html.erb
@@ -18,3 +18,7 @@
     </li><br/>
   <% end %>
 </ul>
+
+<% if user_signed_in? && (current_user.has_role?(:owner, @bot) || current_user.has_role?(:collaborator, @bot))%>
+  <%= link_to "Create New", new_bot_bot_instance_path %>
+<% end %>

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -9,7 +9,7 @@
           <ul>
             <% bot.bot_instances.each do |instance| %>
               <li>
-                <code><%= link_to instance.location, url_for(:controller => :bot_instances, :action => :show, :bot_id => bot.id, :id => instance.id) %></code>
+                <code><%= instance.location %></code>
                 <em>(alive: <span class="<%= instance.status_class %>" title="<%= instance.last_ping %>">
                               <%= instance.last_ping.nil? ? "never" : time_ago_in_words(instance.last_ping) + " ago" %></span>,
                      owner: <%= instance.user.username %>)</em>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,7 @@
       <td><%= user.id %></td>
       <td>
         <% if user.stack_exchange_account_id != 0 then %>
-          <%= user.link %>
+          <%= user_link user %>
         <% else %>
           <%= user.username %>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,7 +14,7 @@
       <td><%= user.id %></td>
       <td>
         <% if user.stack_exchange_account_id != 0 then %>
-          <%= link_to user.username, "//stackexchange.com/users/#{user.stack_exchange_account_id}" %>
+          <%= user.link %>
         <% else %>
           <%= user.username %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'bot_instances/show'
+
     get 'users', to: 'users#index'
 
   devise_for :users


### PR DESCRIPTION
Creating, deleting, and editing bot instances works.  I decided not to create a `show` page for individual instances, since the `index` page already contains all the information that would be there.

Some UX improvements to work on later:

- Navigation back from the instances page.  It should probably be a fixed link that goes back to the bots dashboard.

- Maybe allow modification of instances from the bot's edit page?