### PR TITLE
More friendly error message if an invalid user ID is entered

### DIFF
--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -70,6 +70,14 @@ class BotsController < ApplicationController
   # POST /bots/1/collaborators.json
   def add_collaborator
     bot = Bot.find(params[:bot])
+
+    unless User.exists?(id: params[:collaborator])
+      respond_to do |format|
+        format.html { redirect_to edit_bot_path(bot), flash: { error: 'That user ID does not exist.' } }
+        format.json { render json: 'That user ID does not exist.', status: :not_found }
+      end
+      return
+    end
     collaborator = User.find(params[:collaborator])
 
     if collaborator.has_role?(:collaborator, bot)


### PR DESCRIPTION
Ashish suggested displaying an error instead of 404-ing, which is a good idea because it's easy to enter an invalid user ID.

We probably should come up with a more friendly interface for selecting a user anyway, but I'm not sure what it should be  Maybe a dropdown like Metasmoke's site picker?