### PR TITLE
Sort users alphabetically in the collaborator picker

### DIFF
--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -23,6 +23,7 @@ class BotsController < ApplicationController
   def edit
     @eligible_collaborators = User.where.not(:id => User.with_role(:owner, @bot).pluck(:id))
                                   .where.not(:id => User.with_role(:collaborator, @bot).pluck(:id))
+                                  .order(:username)
                                   .map{ |u| [u.username, u.id] }
   end
 

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -6,6 +6,7 @@ class Bot < ApplicationRecord
   def eligible_collaborators
     User.where.not(:id => User.with_role(:owner, self).pluck(:id))
         .where.not(:id => User.with_role(:collaborator, self).pluck(:id))
+        .order(:username)
         .map{ |u| [u.username, u.id] }
   end
 end


### PR DESCRIPTION
Previously, the users were sorted by user ID.  I thought it looked fine -- in my testing set of only two users (whose IDs were in alphabetical order anyway).