### PR TITLE
Change to display the bots name while editing

### DIFF
--- a/app/views/bots/edit.html.erb
+++ b/app/views/bots/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Bot</h1>
+<h1>Editing <%= @bot.name %></h1>
 
 <%= render 'form', bot: @bot %>
 


### PR DESCRIPTION
Please review this before merging as I don't know anything about ruby.

Whenever you go on the editing page of a bot, the title you see on the top is "Editing Bot". IMO, it would be more descriptive if it would be "Editing [name of the bot here]". 

![selection_159](https://cloud.githubusercontent.com/assets/12422882/23830364/25d6ed9c-072f-11e7-80a8-ec0b7818b85f.png)
