### PR TITLE
Add a "standby" indicator

### DIFF
--- a/app/views/bot_instances/_list_item.html.erb
+++ b/app/views/bot_instances/_list_item.html.erb
@@ -4,4 +4,7 @@
                                 <%= instance.last_ping.nil? ? "never" : time_ago_in_words(instance.last_ping) + " ago" %></span>,
     owner: <%= instance.user.username %>,
     version: <%= instance.version %>)</em>
+    <% if instance != instance.bot.preferred_instance %>
+      <span class="label label-primary ">Standby</span>
+    <% end %>
 </li>

--- a/app/views/bot_instances/index.html.erb
+++ b/app/views/bot_instances/index.html.erb
@@ -7,8 +7,7 @@
         <% if user_signed_in? && (
           current_user.is_owner?(instance.bot) ||
           current_user.is_collaborator?(instance.bot) ||
-          current_user.is_admin? ||
-          current_user.is_developer?) %>
+          current_user.is_admin?) %>
 
           <% if BotInstance.where(bot_id: instance.bot_id).where("priority < ?", instance.priority).exists? %>
             <%= form_tag("/bots/#{instance.bot_id}/bot_instances/reorder") do%>
@@ -28,7 +27,11 @@
 
         <% end %>
       </div>
-      <strong><code><%= instance.location %></code></strong><br/>
+      <strong><code><%= instance.location %></code></strong>
+      <% if instance != instance.bot.preferred_instance %>
+        <span class="label label-primary ">Standby</span>
+      <% end %>
+      <br/>
       <strong>Last pinged:</strong> <span class="<%= instance.status_class %>">
         <% if instance.last_ping.present? %><%= time_ago_in_words(instance.last_ping) %> ago<% else %>Never<% end %></span><br/>
       <strong>Owner:</strong> <%= instance.user.username %>


### PR DESCRIPTION
Add a standby indicator to bot instances which are in standby.  Indicator copied from Metasmoke.

The indicator shows on all instances except the `preferred_instance`.  If all instances are dead, all instances are shown as standby, but I don't think this needs to be fixed.