### PR TITLE
Sort instances on bots dashboard, always display one instance as active

### DIFF
--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -21,9 +21,14 @@ class Bot < ApplicationRecord
   end
 
   def preferred_instance
-    BotInstance.where(bot: self)
+    result = BotInstance.where(bot: self)
                .where('last_ping > ?', 3.minutes.ago)
                .order(:priority)
                .first
+
+    if result == nil
+      return BotInstance.order(:priority).first
+    end
+    return result
   end
 end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -21,13 +21,13 @@ class Bot < ApplicationRecord
   end
 
   def preferred_instance
-    result = BotInstance.where(bot: self)
-               .where('last_ping > ?', 3.minutes.ago)
-               .order(:priority)
-               .first
+    result = bot_instances
+              .where('last_ping > ?', 3.minutes.ago)
+              .order(:priority)
+              .first
 
     if result == nil
-      return BotInstance.order(:priority).first
+      return bot_instances.order(:priority).first
     end
     return result
   end

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -16,7 +16,7 @@
             <p><%= bot.description %></p>
             <p><strong><%= link_to "Instances", url_for(controller: :bot_instances, action: :index, bot_id: bot.id) %></strong></p>
             <ul>
-              <% bot.bot_instances.each do |instance| %>
+              <% bot.bot_instances.order(:priority).each do |instance| %>
                 <%= render 'bot_instances/list_item', :instance => instance %>
               <% end %>
             </ul>


### PR DESCRIPTION
The instances on the bots dashboard are currently sorted by ID; they should be sorted by priority for consistency.

I also changed `preferred_instance` so it doesn't return `nil` when all instances are dead, so one instance will always be displayed as active.  Right now, if all instances are dead, the highest-priority instance is active, but we could change this to be the most recently pinged instance.