### PR TITLE
Update Metasmoke links

### DIFF
--- a/app/assets/javascripts/code_status.coffee
+++ b/app/assets/javascripts/code_status.coffee
@@ -30,7 +30,7 @@ $(document).on 'turbolinks:load', ->
       { default_branch } = repo
       $(".fill-branch")
         .text default_branch
-        .attr "href", "https://github.com/Charcoal-SE/metasmoke/tree/#{default_branch}"
+        .attr "href", "https://github.com/SOBotics/Redunda/tree/#{default_branch}"
 
       status = []
       if compare.ahead_by > 0

--- a/app/views/code_status/index.html.erb
+++ b/app/views/code_status/index.html.erb
@@ -8,7 +8,7 @@
   "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"
 %>
 
-<details open><summary class="h3">Revision <%= link_to "https://github.com/Charcoal-SE/metasmoke/commit/#{CurrentCommit}" do %><code><%= CurrentCommit.first(7) %></code><% end %></summary>
+<details open><summary class="h3">Revision <%= link_to "https://github.com/SOBotics/Redunda/commit/#{CurrentCommit}" do %><code><%= CurrentCommit.first(7) %></code><% end %></summary>
   <div>
     <p>This commit is <span class="fill-status">… commits ahead, … commits behind</span> the <code><%= link_to "...", "", class: "fill-branch" %></code> branch. <%= link_to " diff", "#", id: "toggle-compare-diff", class: "diff-toggle" %> | <%= link_to " commit diff", "#", id: "toggle-commit-diff", class: "diff-toggle" %></p>
     <details class="commit"><summary>Loading commit info…</summary>


### PR DESCRIPTION
The code status page contained a couple of links which pointed to Metasmoke's GH repo.  I updated these links to go to Redunda's instead.