### PR TITLE
Use Unix timestams for created_at and updated_at in data.json

### DIFF
--- a/app/views/bots/list_data.json.jbuilder
+++ b/app/views/bots/list_data.json.jbuilder
@@ -1,6 +1,6 @@
 json.array! @bot_data do |data|
   json.key data.key
-  json.created_at data.created_at
-  json.updated_at data.updated_at
+  json.created_at data.created_at.to_i
+  json.updated_at data.updated_at.to_i
   json.sha256 Digest::SHA256.hexdigest(data.data)
 end


### PR DESCRIPTION
Felix brought this up in #32.  I think we should use Unix time since it's often quite a bit easier to parse, with the only downside I can think of being human-readability (which is not really a concern for `data.json`.