### PR TITLE
Fix navbar in instance list

### DIFF
--- a/app/assets/stylesheets/bot_instances.scss
+++ b/app/assets/stylesheets/bot_instances.scss
@@ -35,7 +35,7 @@ a.view-instance:hover {
   margin-left: -20px;
   float:left;
 }
-.bot-instances {
+.bot-instance-list {
   padding: 0;
   margin: {
     left: -16px;

--- a/app/views/bots/index.html.erb
+++ b/app/views/bots/index.html.erb
@@ -16,7 +16,7 @@
             <% if bot.description.present? %><p><%= bot.description %></p><% end %>
             <% if bot.repository.present? %><p class="text-muted">Repository: <%= repo_link(bot) %></p><% end %>
             <p><strong><%= link_to "Instances", url_for(controller: :bot_instances, action: :index, bot_id: bot.id) %></strong></p>
-            <ul class="bot-instances<%= " no-collaborators" unless bot.collaborators.any? %>">
+            <ul class="bot-instance-list<%= " no-collaborators" unless bot.collaborators.any? %>">
               <% bot.bot_instances.order(:priority).where("last_ping > ?", 1.hour.ago).each do |instance| %>
                 <%= render 'bot_instances/list_item', :instance => instance %>
               <% end %>


### PR DESCRIPTION
The class `bot-instance-ul` was renamed to `bot-instances`.  This broke the navbar for the instance list page, since the `bot-instances` class it automatically applied to the `body` of that page.  I renamed the class to `bot-instance-list` to fix it.