### PR TITLE
Include location in the status ping

### DIFF
--- a/app/views/bot_instances/status_ping.json.jbuilder
+++ b/app/views/bot_instances/status_ping.json.jbuilder
@@ -1,1 +1,2 @@
 json.should_standby !(@bot.preferred_instance == @bot_instance)
+json.location @bot_instance.location


### PR DESCRIPTION
I'd like FireAlarm to be able to get the location name from Redunda to simplify setup.