### PR TITLE
Use the instance owner’s username to format the instance locations

### DIFF
--- a/app/models/bot_instance.rb
+++ b/app/models/bot_instance.rb
@@ -7,6 +7,10 @@ class BotInstance < ApplicationRecord
   belongs_to :bot
   belongs_to :user
 
+  def human_location
+    return "#{self.user.username}/#{self.location}"
+  end
+
   def status
     if last_ping.nil?
       return nil

--- a/app/views/bot_instances/_form.html.erb
+++ b/app/views/bot_instances/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= f.label :location %><br/>
-    <span class="text-muted"><em>Something that describes where this instance is running, e.g. <code>ArtOfCode/EC2</code></em></span>
+    <span class="text-muted"><em>Something that describes where this instance is running, e.g. <code>EC2</code></em></span>
     <%= f.text_field :location, :class => "form-control" %>
   </div><br/>
 

--- a/app/views/bot_instances/_list_item.html.erb
+++ b/app/views/bot_instances/_list_item.html.erb
@@ -1,8 +1,8 @@
 <li id="instance-<%= instance.id %>">
-  <code><%= instance.location %></code>
+  <code><%= instance.human_location %></code>
   <em>(alive: <span class="instance-status <%= instance.status_class %>" title="<%= instance.last_ping %>">
                                 <%= instance.last_ping.nil? ? "never" : time_ago_in_words(instance.last_ping) + " ago" %>
-    </span><% if instance.version.present? && !instance.version.empty? && instance.version != "unspecified" %>, 
+    </span><% if instance.version.present? && !instance.version.empty? && instance.version != "unspecified" %>,
     version: <%= version_link(instance.bot, instance) %><% end %>)</em>
   <% if instance != instance.bot.preferred_instance %>
     <% if instance.status == :okay %>

--- a/app/views/bot_instances/index.html.erb
+++ b/app/views/bot_instances/index.html.erb
@@ -27,7 +27,7 @@
 
         <% end %>
       </div>
-      <strong><code><%= instance.location %></code></strong>
+      <strong><code><%= instance.human_location %></code></strong>
       <% if instance != instance.bot.preferred_instance %>
         <span class="label label-primary ">Standby</span>
       <% end %>

--- a/app/views/bot_instances/status_ping.json.jbuilder
+++ b/app/views/bot_instances/status_ping.json.jbuilder
@@ -1,2 +1,2 @@
 json.should_standby !(@bot.preferred_instance == @bot_instance)
-json.location @bot_instance.location
+json.location @bot_instance.human_location

--- a/db/migrate/20170429203443_remove_username_from_bot_instances.rb
+++ b/db/migrate/20170429203443_remove_username_from_bot_instances.rb
@@ -1,0 +1,12 @@
+class RemoveUsernameFromBotInstances < ActiveRecord::Migration[5.1]
+  def change
+    BotInstance.all.each do |instance|
+      if instance.location.include? "/"
+        segments = instance.location.split "/"
+        segments.shift
+        instance.location = segments.join "/"
+        instance.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
The included migration removes everything up to and including the first `/` in the instance name, if present.