### PR TITLE
Webhook forwarding

### DIFF
--- a/app/controllers/bot_instances_controller.rb
+++ b/app/controllers/bot_instances_controller.rb
@@ -144,7 +144,7 @@ class BotInstancesController < ApplicationController
 
   # Runs after events.json is rendered, to remove the events from the database.
   def destroy_events
-    @events.each { |e| e.destroy! }
+    @events.destroy_all
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -7,11 +7,6 @@ class BotsController < ApplicationController
 
   protect_from_forgery except: [:get_data, :update_data, :remove_data, :add_event]
 
-  # Don't attempt to render a response for add_event
-  # https://stackoverflow.com/a/2062577/3476191
-  layout false
-  layout 'application', :except => :add_event
-
   # GET /bots
   # GET /bots.json
   def index
@@ -190,7 +185,6 @@ class BotsController < ApplicationController
       event = Event.new(bot: @bot, headers: json_headers, content: request.raw_post, name: params[:name])
       event.save!
     end
-    head :no_content
   end
 
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,14 @@
+class EventValidator < ActiveModel::Validator
+  def validate(event)
+    if event.bot == nil && event.bot_instance == nil
+      event.errors[:base] << "An Event must have either a bot or an instance"
+    elsif event.bot != nil && event.bot_instance != nil
+      event.errors[:base] << "An Event may not have both a bot and an instance"
+    end
+  end
+end
+
+class Event < ApplicationRecord
+  belongs_to :bot, optional: true
+  belongs_to :bot_instance, optional: true
+end

--- a/app/views/bot_instances/show_events.json.jbuilder
+++ b/app/views/bot_instances/show_events.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @events do |event|
+  json.name event.name
+  json.is_broadcast event.bot_instance != nil
+  # Unfortunately, it doesn't look like there's a non-hacky way to directly inject JSON into a response
+  json.headers JSON.parse event.headers
+  json.content event.content
+end

--- a/app/views/bot_instances/status_ping.json.jbuilder
+++ b/app/views/bot_instances/status_ping.json.jbuilder
@@ -1,2 +1,3 @@
 json.should_standby !(@bot.preferred_instance == @bot_instance)
 json.location @bot_instance.human_location
+json.event_count Event.where(bot: @bot).count + Event.where(bot_instance: @bot_instance).count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   delete 'bots/data/:data_key', to: 'bots#remove_data', as: :remove_data, constraints: {:data_key => /[\w\.]+/}
   delete 'bots/:id/data/:data_key', to: 'bots#web_remove_data', as: :web_remove_data, constraints: {:data_key => /[\w\.]+/}
 
+  post 'bots/:id/events/:name', to: 'bots#add_event', as: :add_event
+  post 'events.json', to: 'bot_instances#show_events', as: :show_events
+
   resources :bots do
     resources :bot_instances
   end

--- a/db/migrate/20170604231312_create_events.rb
+++ b/db/migrate/20170604231312_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :events do |t|
+      t.references :bot, foreign_key: true
+      t.references :bot_instance, foreign_key: true
+      t.string :headers
+      t.string :content
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170429203443) do
+ActiveRecord::Schema.define(version: 20170604231312) do
 
   create_table "bot_data", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "bot_id"
@@ -44,6 +44,18 @@ ActiveRecord::Schema.define(version: 20170429203443) do
     t.string "repository"
   end
 
+  create_table "events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "bot_id"
+    t.bigint "bot_instance_id"
+    t.string "headers"
+    t.string "content"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bot_id"], name: "index_events_on_bot_id"
+    t.index ["bot_instance_id"], name: "index_events_on_bot_instance_id"
+  end
+
   create_table "roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.string "resource_type"
@@ -74,4 +86,6 @@ ActiveRecord::Schema.define(version: 20170429203443) do
   add_foreign_key "bot_data", "bots"
   add_foreign_key "bot_instances", "bots"
   add_foreign_key "bot_instances", "users"
+  add_foreign_key "events", "bot_instances"
+  add_foreign_key "events", "bots"
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I implemented a simple webhook forwarding system, as described in #46.

When a `POST` request is made to `bots/:id/events/:name`, a new event is added.  A bot instance can fetch new events by `POST`ing it's `key` to `events.json`; this request will return the event's name, request headers, request content, and whether the event is a "broadcast" event.  Fetching the events will remove them from the DB, so `events.json` will only return *new* events.

By default, events will only be delivered to one instance, but "broadcast" events will be delivered to all of the bot's instances.  A broadcast event can be created by setting the `broadcast` parameter to `true`; for example `POST bots/1/events/some_name?broadcast=true`.

**Important: Client-side event validation must be performed.  Since different webhooks implement validation differently, Redunda does not perform any server-side validation; as Art put it, "any old Joe" can create an event.** [ GitHub's webhooks](https://developer.github.com/webhooks/), for example, include a `X-Hub-Signature` header which can be used to validate the event.